### PR TITLE
build: release v0.14.0-0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## [[v0.14.0-0.8.0](https://github.com/line/wasmvm/compare/v0.14.0-0.7.0...v0.14.0-0.8.0)] - 2021-10-01
+
+### Features
+
+* change tag name for static build ([#49](https://github.com/line/wasmvm/issues/49))
+
+
 ## [[0.14.0-0.7.0](https://github.com/line/wasmvm/compare/v0.14.0-0.6.1...0.14.0-0.7.0)] - 2021-09-30
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,7 @@ checksum = "87cc2fe6350834b4e528ba0901e7aa405d78b89dc1fa3145359eb4de0e323fcf"
 
 [[package]]
 name = "wasmvm"
-version = "0.14.0-0.7.0"
+version = "0.14.0-0.8.0"
 dependencies = [
  "cbindgen",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmvm"
-version = "0.14.0-0.7.0"
+version = "0.14.0-0.8.0"
 publish = false
 authors = ["LINE Plus Corporation"]
 edition = "2018"


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

release v0.14.0-0.8.0

The reason for releasing a new version soon after the previous is that the previous version tag was pointed to be a wrong commit. 
I fixed it quickly but the go proxy had cached it already. (https://proxy.golang.org/)

And it generates an error continuously.
```
verifying github.com/line/wasmvm@v0.14.0-0.7.0: checksum mismatch
	downloaded: h1:aLEbXswNuwVcmq4XYDrd2YTrn49X3H5qNVlBLkOyehw=
	go.sum:     h1:1gxArBbo5Yjg+IQWHQHRYlMIgj2JUdPqoDzGGyL/UqM=

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.

For more information, see 'go help module-auth'.
make: *** [Makefile:120: build] Error 1
Error: Process completed with exit code 2.
```

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/wasmvm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
