### PR TITLE
chore: add script for setting version

### DIFF
--- a/devtools/set_version.sh
+++ b/devtools/set_version.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+command -v shellcheck >/dev/null && shellcheck "$0"
+
+gnused="$(command -v gsed || echo sed)"
+
+function print_usage() {
+  echo "Usage: $0 NEW_VERSION"
+  echo ""
+  echo "e.g. $0 0.8.0"
+}
+
+if [ "$#" -ne 1 ]; then
+  print_usage
+  exit 1
+fi
+
+# Check repo
+SCRIPT_DIR="$(realpath "$(dirname "$0")")"
+if [[ "$(realpath "$SCRIPT_DIR/..")" != "$(pwd)" ]]; then
+  echo "Script must be called from the repo root"
+  exit 2
+fi
+
+# Ensure repo is not dirty
+CHANGES_IN_REPO=$(git status --porcelain)
+if [[ -n "$CHANGES_IN_REPO" ]]; then
+  echo "Repository is dirty. Showing 'git status' and 'git --no-pager diff' for debugging now:"
+  git status && git --no-pager diff
+  exit 3
+fi
+
+NEW="$1"
+OLD=$(cargo tree -i wasmvm | grep -oE "[0-9]+(\.[0-9]+){2}-[0-9]+(\.[0-9]+){2}")
+echo "Updating old version $OLD to new version $NEW ..."
+
+CARGO_TOML="Cargo.toml"
+"$gnused" -i -e "s/version[[:space:]]*=[[:space:]]*\"$OLD\"/version = \"$NEW\"/" "$CARGO_TOML"
+
+cargo check


### PR DESCRIPTION
# Description

Add a script for setting the version

usage:
```
Usage: devtools/set_version.sh NEW_VERSION

e.g. devtools/set_version.sh 0.8.0
```


## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/wasmvm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
