### PR TITLE
fix: getmetrics test due to this is environment-dependent test

### DIFF
--- a/api/lib_test.go
+++ b/api/lib_test.go
@@ -197,12 +197,11 @@ func TestGetMetrics(t *testing.T) {
 
 	// GetMetrics 3
 	metrics, err = GetMetrics(cache)
-	require.NoError(t, err)
-	assert.Equal(t, &types.Metrics{
-		HitsFsCache:         1,
-		ElementsMemoryCache: 1,
-		SizeMemoryCache:     5665691,
-	}, metrics)
+	assert.NoError(t, err)
+	require.Equal(t, uint32(0), metrics.HitsMemoryCache)
+	require.Equal(t, uint32(1), metrics.HitsFsCache)
+	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
+	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
 
 	// Instantiate 2
 	msg2 := []byte(`{"verifier": "fred", "beneficiary": "susi"}`)
@@ -211,13 +210,11 @@ func TestGetMetrics(t *testing.T) {
 
 	// GetMetrics 4
 	metrics, err = GetMetrics(cache)
-	require.NoError(t, err)
-	assert.Equal(t, &types.Metrics{
-		HitsMemoryCache:     1,
-		HitsFsCache:         1,
-		ElementsMemoryCache: 1,
-		SizeMemoryCache:     5665691,
-	}, metrics)
+	assert.NoError(t, err)
+	require.Equal(t, uint32(1), metrics.HitsMemoryCache)
+	require.Equal(t, uint32(1), metrics.HitsFsCache)
+	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
+	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
 
 	// Pin
 	err = Pin(cache, checksum)
@@ -225,15 +222,13 @@ func TestGetMetrics(t *testing.T) {
 
 	// GetMetrics 5
 	metrics, err = GetMetrics(cache)
-	require.NoError(t, err)
-	assert.Equal(t, &types.Metrics{
-		HitsMemoryCache:           2,
-		HitsFsCache:               1,
-		ElementsPinnedMemoryCache: 1,
-		ElementsMemoryCache:       1,
-		SizePinnedMemoryCache:     5665691,
-		SizeMemoryCache:           5665691,
-	}, metrics)
+	assert.NoError(t, err)
+	require.Equal(t, uint32(2), metrics.HitsMemoryCache)
+	require.Equal(t, uint32(1), metrics.HitsFsCache)
+	require.Equal(t, uint64(1), metrics.ElementsPinnedMemoryCache)
+	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
+	require.InEpsilon(t, 5602873, metrics.SizePinnedMemoryCache, 0.18)
+	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
 
 	// Instantiate 3
 	msg3 := []byte(`{"verifier": "fred", "beneficiary": "bert"}`)
@@ -242,16 +237,14 @@ func TestGetMetrics(t *testing.T) {
 
 	// GetMetrics 6
 	metrics, err = GetMetrics(cache)
-	require.NoError(t, err)
-	assert.Equal(t, &types.Metrics{
-		HitsPinnedMemoryCache:     1,
-		HitsMemoryCache:           2,
-		HitsFsCache:               1,
-		ElementsPinnedMemoryCache: 1,
-		ElementsMemoryCache:       1,
-		SizePinnedMemoryCache:     5665691,
-		SizeMemoryCache:           5665691,
-	}, metrics)
+	assert.NoError(t, err)
+	require.Equal(t, uint32(1), metrics.HitsPinnedMemoryCache)
+	require.Equal(t, uint32(2), metrics.HitsMemoryCache)
+	require.Equal(t, uint32(1), metrics.HitsFsCache)
+	require.Equal(t, uint64(1), metrics.ElementsPinnedMemoryCache)
+	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
+	require.InEpsilon(t, 5602873, metrics.SizePinnedMemoryCache, 0.18)
+	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
 
 	// Unpin
 	err = Unpin(cache, checksum)
@@ -259,16 +252,14 @@ func TestGetMetrics(t *testing.T) {
 
 	// GetMetrics 7
 	metrics, err = GetMetrics(cache)
-	require.NoError(t, err)
-	assert.Equal(t, &types.Metrics{
-		HitsPinnedMemoryCache:     1,
-		HitsMemoryCache:           2,
-		HitsFsCache:               1,
-		ElementsPinnedMemoryCache: 0,
-		ElementsMemoryCache:       1,
-		SizePinnedMemoryCache:     0,
-		SizeMemoryCache:           5665691,
-	}, metrics)
+	assert.NoError(t, err)
+	require.Equal(t, uint32(1), metrics.HitsPinnedMemoryCache)
+	require.Equal(t, uint32(2), metrics.HitsMemoryCache)
+	require.Equal(t, uint32(1), metrics.HitsFsCache)
+	require.Equal(t, uint64(0), metrics.ElementsPinnedMemoryCache)
+	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
+	require.Equal(t, uint64(0), metrics.SizePinnedMemoryCache)
+	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
 
 	// Instantiate 4
 	msg4 := []byte(`{"verifier": "fred", "beneficiary": "jeff"}`)
@@ -277,16 +268,14 @@ func TestGetMetrics(t *testing.T) {
 
 	// GetMetrics 8
 	metrics, err = GetMetrics(cache)
-	require.NoError(t, err)
-	assert.Equal(t, &types.Metrics{
-		HitsPinnedMemoryCache:     1,
-		HitsMemoryCache:           3,
-		HitsFsCache:               1,
-		ElementsPinnedMemoryCache: 0,
-		ElementsMemoryCache:       1,
-		SizePinnedMemoryCache:     0,
-		SizeMemoryCache:           5665691,
-	}, metrics)
+	assert.NoError(t, err)
+	require.Equal(t, uint32(1), metrics.HitsPinnedMemoryCache)
+	require.Equal(t, uint32(3), metrics.HitsMemoryCache)
+	require.Equal(t, uint32(1), metrics.HitsFsCache)
+	require.Equal(t, uint64(0), metrics.ElementsPinnedMemoryCache)
+	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
+	require.Equal(t, uint64(0), metrics.SizePinnedMemoryCache)
+	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
 }
 
 func TestInstantiate(t *testing.T) {

--- a/api/lib_test.go
+++ b/api/lib_test.go
@@ -201,7 +201,7 @@ func TestGetMetrics(t *testing.T) {
 	require.Equal(t, uint32(0), metrics.HitsMemoryCache)
 	require.Equal(t, uint32(1), metrics.HitsFsCache)
 	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
-	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizeMemoryCache, 0.18)
 
 	// Instantiate 2
 	msg2 := []byte(`{"verifier": "fred", "beneficiary": "susi"}`)
@@ -214,7 +214,7 @@ func TestGetMetrics(t *testing.T) {
 	require.Equal(t, uint32(1), metrics.HitsMemoryCache)
 	require.Equal(t, uint32(1), metrics.HitsFsCache)
 	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
-	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizeMemoryCache, 0.18)
 
 	// Pin
 	err = Pin(cache, checksum)
@@ -227,8 +227,8 @@ func TestGetMetrics(t *testing.T) {
 	require.Equal(t, uint32(1), metrics.HitsFsCache)
 	require.Equal(t, uint64(1), metrics.ElementsPinnedMemoryCache)
 	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
-	require.InEpsilon(t, 5602873, metrics.SizePinnedMemoryCache, 0.18)
-	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizePinnedMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizeMemoryCache, 0.18)
 
 	// Instantiate 3
 	msg3 := []byte(`{"verifier": "fred", "beneficiary": "bert"}`)
@@ -243,8 +243,8 @@ func TestGetMetrics(t *testing.T) {
 	require.Equal(t, uint32(1), metrics.HitsFsCache)
 	require.Equal(t, uint64(1), metrics.ElementsPinnedMemoryCache)
 	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
-	require.InEpsilon(t, 5602873, metrics.SizePinnedMemoryCache, 0.18)
-	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizePinnedMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizeMemoryCache, 0.18)
 
 	// Unpin
 	err = Unpin(cache, checksum)
@@ -259,7 +259,7 @@ func TestGetMetrics(t *testing.T) {
 	require.Equal(t, uint64(0), metrics.ElementsPinnedMemoryCache)
 	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
 	require.Equal(t, uint64(0), metrics.SizePinnedMemoryCache)
-	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizeMemoryCache, 0.18)
 
 	// Instantiate 4
 	msg4 := []byte(`{"verifier": "fred", "beneficiary": "jeff"}`)
@@ -275,7 +275,7 @@ func TestGetMetrics(t *testing.T) {
 	require.Equal(t, uint64(0), metrics.ElementsPinnedMemoryCache)
 	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
 	require.Equal(t, uint64(0), metrics.SizePinnedMemoryCache)
-	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizeMemoryCache, 0.18)
 }
 
 func TestInstantiate(t *testing.T) {

--- a/lib_test.go
+++ b/lib_test.go
@@ -132,12 +132,11 @@ func TestGetMetrics(t *testing.T) {
 
 	// GetMetrics 3
 	metrics, err = vm.GetMetrics()
-	require.NoError(t, err)
-	assert.Equal(t, &types.Metrics{
-		HitsFsCache:         1,
-		ElementsMemoryCache: 1,
-		SizeMemoryCache:     5665691,
-	}, metrics)
+	assert.NoError(t, err)
+	require.Equal(t, uint32(0), metrics.HitsMemoryCache)
+	require.Equal(t, uint32(1), metrics.HitsFsCache)
+	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
+	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
 
 	// Instantiate 2
 	msg2 := []byte(`{"verifier": "fred", "beneficiary": "susi"}`)
@@ -147,13 +146,11 @@ func TestGetMetrics(t *testing.T) {
 
 	// GetMetrics 4
 	metrics, err = vm.GetMetrics()
-	require.NoError(t, err)
-	assert.Equal(t, &types.Metrics{
-		HitsMemoryCache:     1,
-		HitsFsCache:         1,
-		ElementsMemoryCache: 1,
-		SizeMemoryCache:     5665691,
-	}, metrics)
+	assert.NoError(t, err)
+	require.Equal(t, uint32(1), metrics.HitsMemoryCache)
+	require.Equal(t, uint32(1), metrics.HitsFsCache)
+	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
+	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
 
 	// Pin
 	err = vm.Pin(checksum)
@@ -161,15 +158,13 @@ func TestGetMetrics(t *testing.T) {
 
 	// GetMetrics 5
 	metrics, err = vm.GetMetrics()
-	require.NoError(t, err)
-	assert.Equal(t, &types.Metrics{
-		HitsMemoryCache:           2,
-		HitsFsCache:               1,
-		ElementsPinnedMemoryCache: 1,
-		ElementsMemoryCache:       1,
-		SizePinnedMemoryCache:     5665691,
-		SizeMemoryCache:           5665691,
-	}, metrics)
+	assert.NoError(t, err)
+	require.Equal(t, uint32(2), metrics.HitsMemoryCache)
+	require.Equal(t, uint32(1), metrics.HitsFsCache)
+	require.Equal(t, uint64(1), metrics.ElementsPinnedMemoryCache)
+	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
+	require.InEpsilon(t, 5602873, metrics.SizePinnedMemoryCache, 0.18)
+	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
 
 	// Instantiate 3
 	msg3 := []byte(`{"verifier": "fred", "beneficiary": "bert"}`)
@@ -179,16 +174,14 @@ func TestGetMetrics(t *testing.T) {
 
 	// GetMetrics 6
 	metrics, err = vm.GetMetrics()
-	require.NoError(t, err)
-	assert.Equal(t, &types.Metrics{
-		HitsPinnedMemoryCache:     1,
-		HitsMemoryCache:           2,
-		HitsFsCache:               1,
-		ElementsPinnedMemoryCache: 1,
-		ElementsMemoryCache:       1,
-		SizePinnedMemoryCache:     5665691,
-		SizeMemoryCache:           5665691,
-	}, metrics)
+	assert.NoError(t, err)
+	require.Equal(t, uint32(1), metrics.HitsPinnedMemoryCache)
+	require.Equal(t, uint32(2), metrics.HitsMemoryCache)
+	require.Equal(t, uint32(1), metrics.HitsFsCache)
+	require.Equal(t, uint64(1), metrics.ElementsPinnedMemoryCache)
+	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
+	require.InEpsilon(t, 5602873, metrics.SizePinnedMemoryCache, 0.18)
+	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
 
 	// Unpin
 	err = vm.Unpin(checksum)
@@ -196,16 +189,14 @@ func TestGetMetrics(t *testing.T) {
 
 	// GetMetrics 7
 	metrics, err = vm.GetMetrics()
-	require.NoError(t, err)
-	assert.Equal(t, &types.Metrics{
-		HitsPinnedMemoryCache:     1,
-		HitsMemoryCache:           2,
-		HitsFsCache:               1,
-		ElementsPinnedMemoryCache: 0,
-		ElementsMemoryCache:       1,
-		SizePinnedMemoryCache:     0,
-		SizeMemoryCache:           5665691,
-	}, metrics)
+	assert.NoError(t, err)
+	require.Equal(t, uint32(1), metrics.HitsPinnedMemoryCache)
+	require.Equal(t, uint32(2), metrics.HitsMemoryCache)
+	require.Equal(t, uint32(1), metrics.HitsFsCache)
+	require.Equal(t, uint64(0), metrics.ElementsPinnedMemoryCache)
+	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
+	require.Equal(t, uint64(0), metrics.SizePinnedMemoryCache)
+	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
 
 	// Instantiate 4
 	msg4 := []byte(`{"verifier": "fred", "beneficiary": "jeff"}`)
@@ -215,14 +206,12 @@ func TestGetMetrics(t *testing.T) {
 
 	// GetMetrics 8
 	metrics, err = vm.GetMetrics()
-	require.NoError(t, err)
-	assert.Equal(t, &types.Metrics{
-		HitsPinnedMemoryCache:     1,
-		HitsMemoryCache:           3,
-		HitsFsCache:               1,
-		ElementsPinnedMemoryCache: 0,
-		ElementsMemoryCache:       1,
-		SizePinnedMemoryCache:     0,
-		SizeMemoryCache:           5665691,
-	}, metrics)
+	assert.NoError(t, err)
+	require.Equal(t, uint32(1), metrics.HitsPinnedMemoryCache)
+	require.Equal(t, uint32(3), metrics.HitsMemoryCache)
+	require.Equal(t, uint32(1), metrics.HitsFsCache)
+	require.Equal(t, uint64(0), metrics.ElementsPinnedMemoryCache)
+	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
+	require.Equal(t, uint64(0), metrics.SizePinnedMemoryCache)
+	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
 }

--- a/lib_test.go
+++ b/lib_test.go
@@ -136,7 +136,7 @@ func TestGetMetrics(t *testing.T) {
 	require.Equal(t, uint32(0), metrics.HitsMemoryCache)
 	require.Equal(t, uint32(1), metrics.HitsFsCache)
 	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
-	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizeMemoryCache, 0.18)
 
 	// Instantiate 2
 	msg2 := []byte(`{"verifier": "fred", "beneficiary": "susi"}`)
@@ -150,7 +150,7 @@ func TestGetMetrics(t *testing.T) {
 	require.Equal(t, uint32(1), metrics.HitsMemoryCache)
 	require.Equal(t, uint32(1), metrics.HitsFsCache)
 	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
-	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizeMemoryCache, 0.18)
 
 	// Pin
 	err = vm.Pin(checksum)
@@ -163,8 +163,8 @@ func TestGetMetrics(t *testing.T) {
 	require.Equal(t, uint32(1), metrics.HitsFsCache)
 	require.Equal(t, uint64(1), metrics.ElementsPinnedMemoryCache)
 	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
-	require.InEpsilon(t, 5602873, metrics.SizePinnedMemoryCache, 0.18)
-	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizePinnedMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizeMemoryCache, 0.18)
 
 	// Instantiate 3
 	msg3 := []byte(`{"verifier": "fred", "beneficiary": "bert"}`)
@@ -180,8 +180,8 @@ func TestGetMetrics(t *testing.T) {
 	require.Equal(t, uint32(1), metrics.HitsFsCache)
 	require.Equal(t, uint64(1), metrics.ElementsPinnedMemoryCache)
 	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
-	require.InEpsilon(t, 5602873, metrics.SizePinnedMemoryCache, 0.18)
-	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizePinnedMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizeMemoryCache, 0.18)
 
 	// Unpin
 	err = vm.Unpin(checksum)
@@ -196,7 +196,7 @@ func TestGetMetrics(t *testing.T) {
 	require.Equal(t, uint64(0), metrics.ElementsPinnedMemoryCache)
 	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
 	require.Equal(t, uint64(0), metrics.SizePinnedMemoryCache)
-	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizeMemoryCache, 0.18)
 
 	// Instantiate 4
 	msg4 := []byte(`{"verifier": "fred", "beneficiary": "jeff"}`)
@@ -213,5 +213,5 @@ func TestGetMetrics(t *testing.T) {
 	require.Equal(t, uint64(0), metrics.ElementsPinnedMemoryCache)
 	require.Equal(t, uint64(1), metrics.ElementsMemoryCache)
 	require.Equal(t, uint64(0), metrics.SizePinnedMemoryCache)
-	require.InEpsilon(t, 5602873, metrics.SizeMemoryCache, 0.18)
+	require.InEpsilon(t, 5665691, metrics.SizeMemoryCache, 0.18)
 }

--- a/libwasmvm/src/cache.rs
+++ b/libwasmvm/src/cache.rs
@@ -709,7 +709,7 @@ mod tests {
         assert_eq!(misses, 0);
         assert_eq!(elements_pinned_memory_cache, 1);
         assert_eq!(elements_memory_cache, 0);
-        let expected = 5602873; // +/- 20%
+        let expected = 5665691; // +/- 20%
         assert!(
             size_pinned_memory_cache > expected * 80 / 100,
             "size_pinned_memory_cache: {}",

--- a/libwasmvm/src/cache.rs
+++ b/libwasmvm/src/cache.rs
@@ -693,19 +693,34 @@ mod tests {
         let mut error_msg = UnmanagedVector::default();
         let metrics = get_metrics(cache_ptr, Some(&mut error_msg));
         let _ = error_msg.consume();
-        assert_eq!(
-            metrics,
-            Metrics {
-                hits_pinned_memory_cache: 0,
-                hits_memory_cache: 0,
-                hits_fs_cache: 1,
-                misses: 0,
-                elements_pinned_memory_cache: 1,
-                elements_memory_cache: 0,
-                size_pinned_memory_cache: 5665691,
-                size_memory_cache: 0,
-            }
+        let Metrics {
+            hits_pinned_memory_cache,
+            hits_memory_cache,
+            hits_fs_cache,
+            misses,
+            elements_pinned_memory_cache,
+            elements_memory_cache,
+            size_pinned_memory_cache,
+            size_memory_cache,
+        } = metrics;
+        assert_eq!(hits_pinned_memory_cache, 0);
+        assert_eq!(hits_memory_cache, 0);
+        assert_eq!(hits_fs_cache, 1);
+        assert_eq!(misses, 0);
+        assert_eq!(elements_pinned_memory_cache, 1);
+        assert_eq!(elements_memory_cache, 0);
+        let expected = 5602873; // +/- 20%
+        assert!(
+            size_pinned_memory_cache > expected * 80 / 100,
+            "size_pinned_memory_cache: {}",
+            size_pinned_memory_cache
         );
+        assert!(
+            size_pinned_memory_cache < expected * 120 / 100,
+            "size_pinned_memory_cache: {}",
+            size_pinned_memory_cache
+        );
+        assert_eq!(size_memory_cache, 0);
 
         // Unpin
         let mut error_msg = UnmanagedVector::default();


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

The `get_metrics` and `GetMetrics` test fails when the test is performed in a different environment, such as the M1 environment, so the test has been fixed.
A similar error was found in `CosmWasm/wasmvm`, so the test were fixed in the same way.
- https://github.com/CosmWasm/wasmvm/issues/340
- https://github.com/CosmWasm/wasmvm/pull/351


## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/wasmvm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
