### PR TITLE
fix: change the type of GetContractEnv's 2nd arg from *Cache to Cache

### DIFF
--- a/api/callbacks.go
+++ b/api/callbacks.go
@@ -370,7 +370,7 @@ func cNext(ref C.iterator_t, gasMeter *C.gas_meter_t, usedGas *C.uint64_t, key *
 type (
 	HumanizeAddress     func([]byte) (string, uint64, error)
 	CanonicalizeAddress func(string) ([]byte, uint64, error)
-	GetContractEnv      func(string, uint64) (Env, *Cache, KVStore, Querier, GasMeter, []byte, uint64, uint64, error)
+	GetContractEnv      func(string, uint64) (Env, Cache, KVStore, Querier, GasMeter, []byte, uint64, uint64, error)
 )
 
 type GoAPI struct {

--- a/lib.go
+++ b/lib.go
@@ -759,8 +759,8 @@ func (vm *VM) IBCPacketTimeout(
 	return resp.Ok, gasUsed, nil
 }
 
-func (vm *VM) GetCache() *Cache {
-	return &vm.cache
+func (vm *VM) GetCache() Cache {
+	return vm.cache
 }
 
 // LibwasmvmVersion returns the version of the loaded library


### PR DESCRIPTION
# Description

This PR changes the type of GetContractEnv's 2nd arg from *Cache to Cache
see #90 for detail.

closes #90 

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [x] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/wasmvm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (NOT NEEDED)
- [ ] I have added tests to cover my changes. (NOT NEEDED)
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
